### PR TITLE
Correct text typos in modal for all sales page carts

### DIFF
--- a/src/app/sites/design/feng-shui-overview/modal.tsx
+++ b/src/app/sites/design/feng-shui-overview/modal.tsx
@@ -12,8 +12,8 @@ export const FSModal: FC<Props> = props => (
   <Modal show={props.show} onHide={props.onHide}>
     <Modal.Header closeButton>Start Your Journey in Feng Shui Design</Modal.Header>
     <Modal.Body>
-      <p>For a limited time, enroll in Feng Shui Design for $998&mdash;that&apos;s a savings of $250 when you pay in full.</p>
-      <p>Prefer paying over time? Save up $150 with our monthly installment plan. This is your chance to launch your design career with our biggest savings ever. Act now before this offer is gone!</p>
+      <p>For a limited time, enroll in Feng Shui Design for $998&mdash;that&apos;s a savings of $600 when you pay in full.</p>
+      <p>Prefer paying over time? Save up to $150 with our monthly installment plan. This is your chance to launch your design career with our biggest savings ever. Act now before this offer is gone!</p>
 
       <hr />
       <h6 className="sans-serif">Learn From Expert Instructors</h6>

--- a/src/app/sites/design/floral-design-overview/modal.tsx
+++ b/src/app/sites/design/floral-design-overview/modal.tsx
@@ -13,7 +13,7 @@ export const FDModal: FC<Props> = props => (
     <Modal.Header closeButton>Start Your Career in Floral Design</Modal.Header>
     <Modal.Body>
       <p>For a limited time, enroll in Floral Design for $998&mdash;that&apos;s a savings of $500 when you pay in full.</p>
-      <p>Prefer paying over time? Save up $150 with our monthly installment plan. This is your chance to launch your floral design career with our biggest savings ever. Act now before this offer is gone!</p>
+      <p>Prefer paying over time? Save up to $150 with our monthly installment plan. This is your chance to launch your floral design career with our biggest savings ever. Act now before this offer is gone!</p>
 
       <hr />
       <h6 className="sans-serif">Learn From Expert Instructors</h6>

--- a/src/app/sites/design/home-staging-overview/modal.tsx
+++ b/src/app/sites/design/home-staging-overview/modal.tsx
@@ -13,7 +13,7 @@ export const STModal: FC<Props> = props => (
     <Modal.Header closeButton>Start Your Career in Home Staging</Modal.Header>
     <Modal.Body>
       <p>For a limited time, enroll in Home Staging for $998&mdash;that&apos;s a savings of $500 when you pay in full.</p>
-      <p>Prefer paying over time? Save up $150 with our monthly installment plan. This is your chance to launch your design career with our biggest savings ever. Act now before this offer is gone!</p>
+      <p>Prefer paying over time? Save up to $150 with our monthly installment plan. This is your chance to launch your design career with our biggest savings ever. Act now before this offer is gone!</p>
 
       <hr />
       <h6 className="sans-serif">Learn From Expert Instructors</h6>

--- a/src/app/sites/design/landscape-design-overview/modal.tsx
+++ b/src/app/sites/design/landscape-design-overview/modal.tsx
@@ -13,7 +13,7 @@ export const LDModal: FC<Props> = props => (
     <Modal.Header closeButton>Start Your Career in Landscape Design</Modal.Header>
     <Modal.Body>
       <p>For a limited time, enroll in Landscape Design for $998&mdash;that&apos;s a savings of $550 when you pay in full.</p>
-      <p>Prefer paying over time? Save up $150 with our monthly installment plan. This is your chance to launch your design career with our biggest savings ever. Act now before this offer is gone!</p>
+      <p>Prefer paying over time? Save up to $150 with our monthly installment plan. This is your chance to launch your design career with our biggest savings ever. Act now before this offer is gone!</p>
 
       <hr />
       <h6 className="sans-serif">Learn From Expert Instructors</h6>

--- a/src/app/sites/design/professional-organizing-overview/modal.tsx
+++ b/src/app/sites/design/professional-organizing-overview/modal.tsx
@@ -13,7 +13,7 @@ export const POModal: FC<Props> = props => (
     <Modal.Header closeButton>Start Your Career in Professional Organizing</Modal.Header>
     <Modal.Body>
       <p>For a limited time, enroll in Professional Organizing for $998&mdash;that&apos;s a savings of $250 when you pay in full.</p>
-      <p>Prefer paying over time? Save up $150 with our monthly installment plan. This is your chance to launch your design career with our biggest savings ever. Act now before this offer is gone!</p>
+      <p>Prefer paying over time? Save up to $150 with our monthly installment plan. This is your chance to launch your design career with our biggest savings ever. Act now before this offer is gone!</p>
 
       <hr />
       <h6 className="sans-serif">Learn From Expert Instructors</h6>

--- a/src/app/sites/event/floral-design-overview/modal.tsx
+++ b/src/app/sites/event/floral-design-overview/modal.tsx
@@ -13,7 +13,7 @@ export const FDModal: FC<Props> = props => (
     <Modal.Header closeButton>Start Your Career in Floral Design</Modal.Header>
     <Modal.Body>
       <p>For a limited time, enroll in Floral Design for $998&mdash;that&apos;s a savings of $500 when you pay in full.</p>
-      <p>Prefer paying over time? Save up $150 with our monthly installment plan. This is your chance to launch your floral design career with our biggest savings ever. Act now before this offer is gone!</p>
+      <p>Prefer paying over time? Save up to $150 with our monthly installment plan. This is your chance to launch your floral design career with our biggest savings ever. Act now before this offer is gone!</p>
 
       <hr />
       <h6 className="sans-serif">Learn From Expert Instructors</h6>


### PR DESCRIPTION
Change "save up $150" to "save up to $150" 
For the Feng Shui cart, change "that's a savings of $250" to "that's a savings of $600"